### PR TITLE
runCommand $command as string

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -353,7 +353,7 @@ class Shell extends CakeObject {
  * @return bool
  * @link https://book.cakephp.org/2.0/en/console-and-shells.html#Shell::hasMethod
  */
-	public function hasMethod($name) {
+	public function hasMethod(string $name) {
 		try {
 			$method = new ReflectionMethod($this, $name);
 			if (!$method->isPublic() || substr($name, 0, 1) === '_') {
@@ -418,7 +418,7 @@ class Shell extends CakeObject {
  * @return int|bool
  * @link https://book.cakephp.org/2.0/en/console-and-shells.html#Shell::runCommand
  */
-	public function runCommand($command, $argv) {
+	public function runCommand(string $command, $argv) {
 		$isTask = $this->hasTask($command);
 		$isMethod = $this->hasMethod($command);
 		$isMain = $this->hasMethod('main');

--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -212,7 +212,7 @@ class ShellDispatcher {
 
 		$Shell = $this->_getShell($shell);
 
-		$command = null;
+		$command = '';
 		if (isset($this->args[0])) {
 			$command = $this->args[0];
 		}

--- a/lib/Cake/Test/Case/Console/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/ShellTest.php
@@ -724,7 +724,7 @@ class ShellTest extends CakeTestCase {
 		$Mock = $this->getMock('Shell', array('main', 'startup'), array(), '', false);
 
 		$Mock->expects($this->once())->method('main')->will($this->returnValue(true));
-		$result = $Mock->runCommand(null, array());
+		$result = $Mock->runCommand('', array());
 		$this->assertTrue($result);
 	}
 
@@ -815,7 +815,7 @@ class ShellTest extends CakeTestCase {
 			->will($this->returnValue($Parser));
 		$Shell->expects($this->once())->method('out');
 
-		$Shell->runCommand(null, array('--help'));
+		$Shell->runCommand('', array('--help'));
 	}
 
 /**


### PR DESCRIPTION
Related to #10 

- Fixes issue preventing to send `null` to ReflectionMethod.
- Sets typehint for runCommand argument as string in Shell class based on description.
- Fixes original default behavior to send string $command rather than `null` in ShellDispatcher class.
- Updates related unit testing.