### PR TITLE
Fix schema migration that creates multiple UNIQUE indexes at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ It means that composer will look at `master` branch of repository configured und
 
 ## Changelog
 
+### 2022-09-27
+
+- Fixed multiple `CREATE UNIQUE INDEX` statements from schema shell that did not work on PostgreSQL.
+
 ### 2022-03-08
 
 - Fixed passing `params["pass"]` argument to `invokeArgs` when resolving controller action - `array_values` used to avoid problems with named parameters.

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -488,7 +488,7 @@ class DboSource extends DataSource {
  */
 	protected function _execute($sql, $params = array(), $prepareOptions = array()) {
 		$sql = trim($sql);
-		if (preg_match('/^(?:CREATE|ALTER|DROP)\s+(?:TABLE|INDEX)/i', $sql)) {
+		if (preg_match('/^(?:CREATE|ALTER|DROP)\s+(?:UNIQUE\s+)?(?:TABLE|INDEX)/i', $sql)) {
 			$statements = array_filter(explode(';', $sql));
 			if (count($statements) > 1) {
 				$result = array_map(array($this, '_execute'), $statements);


### PR DESCRIPTION
Cake's schema shell cannot migrate a (Postgresql) database if the migration for a table requires only the creation of multiple unique indices. In the first step, CakePHP generates correct SQL: 
```sql
CREATE UNIQUE INDEX users_username_unique ON users ("username");
CREATE UNIQUE INDEX users_email_unique ON users ("email");
```
In the second step, however, Cake tries to execute all commands in a single statement, which is obviously wrong. The error is in DboSource.php, which checks if a line begins with `CREATE INDEX`, but does not know `CREATE UNIQUE INDEX`. The fix extends this check.

I'm not sure if the error originates in this fork or the original CakePHP.