### PR TITLE
$_FILES has new "full_path" field as of PHP 8.1 - include in security hash

### DIFF
--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -1803,6 +1803,9 @@ class FormHelper extends AppHelper {
 		foreach (array('name', 'type', 'tmp_name', 'error', 'size') as $suffix) {
 			$this->_secure($secure, array_merge($field, array($suffix)));
 		}
+		if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
+			$this->_secure($secure, array_merge($field, array('full_path')));
+		}
 
 		$exclude = array('name' => null, 'value' => null);
 		return $this->Html->useTag('file', $options['name'], array_diff_key($options, $exclude));


### PR DESCRIPTION
With PHP 8.1, the array `$_FILES` contains a new field for each uploaded form: `$_FILES['userfile']['full_path']`
See [https://www.php.net/manual/en/features.file-upload.post-method.php](https://www.php.net/manual/en/features.file-upload.post-method.php) for details.

This new field breaks CakePHP's security hash system from SecurityComponent and FormComponent, which hash all fields in a form before submission and checks the hash after submission.

This patch adds the field when creating the hash in FormComponent if PHP is 8.1 or newer.

Steps to reproduce: Enable SecurityComponent, use the FormHelper to create a POST form with file upload, submit.