### PR TITLE
fix: Relative time may not be cached if specified in CacheHelper duration

### DIFF
--- a/lib/Cake/Test/Case/Routing/DispatcherTest.php
+++ b/lib/Cake/Test/Case/Routing/DispatcherTest.php
@@ -1605,12 +1605,6 @@ class DispatcherTest extends CakeTestCase {
  * @return void
  */
 	public function testFullPageCachingDispatch($url) {
-		// PHP 8.0+ has a bug in which the expiration date is not cached
-		// if the expiration date is specified as a relative time.
-		if (PHP_MAJOR_VERSION >= 8) {
-			$this->markTestIncomplete('If an expiration date is specified as a relative time, it cannot be cached.');
-		}
-
 		Configure::write('Cache.disable', false);
 		Configure::write('Cache.check', true);
 		Configure::write('debug', 2);

--- a/lib/Cake/Test/Case/View/Helper/CacheHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/CacheHelperTest.php
@@ -139,11 +139,6 @@ class CacheHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testLayoutCacheParsingNoTagsInViewWithRelativeDuration() {
-		// PHP 8.0+ has a bug in which the expiration date is not cached
-		// if the expiration date is specified as a relative time.
-		if (PHP_MAJOR_VERSION >= 8) {
-			$this->markTestIncomplete('If an expiration date is specified as a relative time, it cannot be cached.');
-		}
 		$this->Controller->cache_parsing();
 		$this->Controller->request->addParams(array(
 			'controller' => 'cache_test',

--- a/lib/Cake/View/Helper/CacheHelper.php
+++ b/lib/Cake/View/Helper/CacheHelper.php
@@ -149,7 +149,7 @@ class CacheHelper extends AppHelper {
 			$cacheTime = $cacheAction;
 		}
 
-		if ($cacheTime && $cacheTime > 0) {
+		if ($cacheTime && ($cacheTime > 0 || isset(date_parse($cacheTime)['relative']))) {
 			$cached = $this->_parseOutput($out);
 			try {
 				$this->_writeFile($cached, $cacheTime, $useCallbacks);


### PR DESCRIPTION
 #26 fix