### PR TITLE
fix: PaginatorHelper::numbers() generates extra separator string in PHP 8.0+

### DIFF
--- a/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/PaginatorHelperTest.php
@@ -1493,11 +1493,6 @@ class PaginatorHelperTest extends CakeTestCase {
  * @return void
  */
 	public function testNumbers() {
-		// In PHP 8.0, the behavior of comparison operators has changed
-		// and the behavior of $offset = "last" has changed. So the test fails.
-		if (PHP_MAJOR_VERSION >= 8) {
-			$this->markTestIncomplete('In PHP 8.0, fail test.');
-		}
 		$this->Paginator->request->params['paging'] = array(
 			'Client' => array(
 				'page' => 8,

--- a/lib/Cake/View/Helper/PaginatorHelper.php
+++ b/lib/Cake/View/Helper/PaginatorHelper.php
@@ -822,7 +822,8 @@ class PaginatorHelper extends AppHelper {
 			if ($last && $end < $params['pageCount']) {
 				$lastPage = is_int($last) ? $last : 0;
 				$offset = ($params['pageCount'] < $end + $lastPage) ? $params['pageCount'] - $end : $last;
-				if ($offset <= $lastPage && $params['pageCount'] - $end > $lastPage) {
+				$offsetIsLabel = (!is_int($offset) && !ctype_digit($offset));
+				if (($offsetIsLabel || $offset <= $lastPage) && $params['pageCount'] - $end > $lastPage) {
 					$out .= $this->last($offset, compact('tag', 'separator', 'ellipsis', 'class'));
 				} else {
 					$out .= $this->last($offset, compact('tag', 'separator', 'class', 'ellipsis') + array('before' => $separator));


### PR DESCRIPTION
#29 fixed.