### PR TITLE
Passing tests with PHP8.1 & MySQL 

### DIFF
--- a/app/Config/database.php.default
+++ b/app/Config/database.php.default
@@ -49,7 +49,7 @@
  * database. Uses database default not specified.
  *
  * sslmode =>
- * For Postgres specifies whether to 'disable', 'allow', 'prefer', or 'require' SSL for the 
+ * For Postgres specifies whether to 'disable', 'allow', 'prefer', or 'require' SSL for the
  * connection. The default value is 'allow'.
  *
  * unix_socket =>
@@ -75,6 +75,15 @@ class DATABASE_CONFIG {
 		'database' => 'database_name',
 		'prefix' => '',
 		//'encoding' => 'utf8',
+
+		// PDO MySQL/SQLite Driver had the following backward incompatible changes in PHP 8.1
+		// * https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.pdo.mysql
+		// * https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.pdo.sqlite
+		// If under PHP 8.1 and didn't use the following flags, adding them will cause integer and float columns
+		// in the result set to be strings as before.
+		//	'flags' => array(
+		//		PDO::ATTR_STRINGIFY_FETCHES => true
+		//	)
 	);
 
 	public $test = array(
@@ -86,5 +95,9 @@ class DATABASE_CONFIG {
 		'database' => 'test_database_name',
 		'prefix' => '',
 		//'encoding' => 'utf8',
+
+		//	'flags' => array(
+		//		PDO::ATTR_STRINGIFY_FETCHES => true
+		//	)
 	);
 }

--- a/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/Database/MysqlTest.php
@@ -214,19 +214,19 @@ class MysqlTest extends CakeTestCase {
 		$this->assertTrue((bool)$this->model->save(array('bool' => 5, 'tiny_int' => 5)));
 		$result = $this->model->find('first');
 		$this->assertTrue($result['Tinyint']['bool']);
-		$this->assertSame($result['Tinyint']['tiny_int'], '5');
+		$this->assertEquals($result['Tinyint']['tiny_int'], '5');
 		$this->model->deleteAll(true);
 
 		$this->assertTrue((bool)$this->model->save(array('bool' => 0, 'tiny_int' => 100)));
 		$result = $this->model->find('first');
 		$this->assertFalse($result['Tinyint']['bool']);
-		$this->assertSame($result['Tinyint']['tiny_int'], '100');
+		$this->assertEquals($result['Tinyint']['tiny_int'], '100');
 		$this->model->deleteAll(true);
 
 		$this->assertTrue((bool)$this->model->save(array('bool' => true, 'tiny_int' => 0)));
 		$result = $this->model->find('first');
 		$this->assertTrue($result['Tinyint']['bool']);
-		$this->assertSame($result['Tinyint']['tiny_int'], '0');
+		$this->assertEquals($result['Tinyint']['tiny_int'], '0');
 		$this->model->deleteAll(true);
 
 		$this->Dbo->rawQuery('DROP TABLE ' . $this->Dbo->fullTableName($tableName));

--- a/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
+++ b/lib/Cake/Test/Case/Model/Datasource/DboSourceTest.php
@@ -1425,10 +1425,10 @@ class DboSourceTest extends CakeTestCase {
 		$db->nestedSupport = true;
 
 		$conn->expects($this->at(0))->method('beginTransaction')->will($this->returnValue(true));
-		$conn->expects($this->at(1))->method('exec')->with($this->equalTo('SAVEPOINT LEVEL1'))->will($this->returnValue(true));
-		$conn->expects($this->at(2))->method('exec')->with($this->equalTo('RELEASE SAVEPOINT LEVEL1'))->will($this->returnValue(true));
-		$conn->expects($this->at(3))->method('exec')->with($this->equalTo('SAVEPOINT LEVEL1'))->will($this->returnValue(true));
-		$conn->expects($this->at(4))->method('exec')->with($this->equalTo('ROLLBACK TO SAVEPOINT LEVEL1'))->will($this->returnValue(true));
+		$conn->expects($this->at(1))->method('exec')->with($this->equalTo('SAVEPOINT LEVEL1'))->will($this->returnValue(0));
+		$conn->expects($this->at(2))->method('exec')->with($this->equalTo('RELEASE SAVEPOINT LEVEL1'))->will($this->returnValue(0));
+		$conn->expects($this->at(3))->method('exec')->with($this->equalTo('SAVEPOINT LEVEL1'))->will($this->returnValue(0));
+		$conn->expects($this->at(4))->method('exec')->with($this->equalTo('ROLLBACK TO SAVEPOINT LEVEL1'))->will($this->returnValue(0));
 		$conn->expects($this->at(5))->method('commit')->will($this->returnValue(true));
 
 		$this->_runTransactions($db);

--- a/lib/Cake/Test/Case/Utility/DebuggerTest.php
+++ b/lib/Cake/Test/Case/Utility/DebuggerTest.php
@@ -642,6 +642,10 @@ TEXT;
  * @return void
  */
 	public function testExportVarRecursion() {
+		$this->skipIf(
+			version_compare(PHP_VERSION, '8.1.0', '>='),
+			'PHP 8.1+, $GLOBALS no longer has $GLOBALS as an element.'
+		);
 		$output = Debugger::exportVar($GLOBALS);
 		$this->assertStringContainsString("'GLOBALS' => [recursion]", $output);
 	}

--- a/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
+++ b/lib/Cake/Test/Case/View/Helper/FormHelperTest.php
@@ -1699,11 +1699,13 @@ class FormHelperTest extends CakeTestCase {
 	}
 
 /**
- * Tests that the correct keys are added to the field hash index
+ * Tests that the correct keys are added to the field hash index (For PHP < 8.1)
  *
  * @return void
  */
 	public function testSecuredFileInput() {
+		$this->skipIf(version_compare(PHP_VERSION, '8.1.0', '>='));
+
 		$this->Form->request['_Token'] = array('key' => 'testKey');
 		$this->assertEquals(array(), $this->Form->fields);
 
@@ -1711,6 +1713,28 @@ class FormHelperTest extends CakeTestCase {
 		$expected = array(
 			'Attachment.file.name', 'Attachment.file.type', 'Attachment.file.tmp_name',
 			'Attachment.file.error', 'Attachment.file.size'
+		);
+		$this->assertEquals($expected, $this->Form->fields);
+	}
+
+/**
+ * Tests that the correct keys are added to the field hash index (For PHP >= 8.1)
+ *
+ * Added full_path key
+ *
+ * @see https://www.php.net/manual/en/migration81.new-features.php#migration81.new-features.core.upload-full-path-key
+ * @return void
+ */
+	public function testSecuredFileInputForPhp81Plus() {
+		$this->skipIf(version_compare(PHP_VERSION, '8.1.0', '<'));
+
+		$this->Form->request['_Token'] = array('key' => 'testKey');
+		$this->assertEquals(array(), $this->Form->fields);
+
+		$this->Form->file('Attachment.file');
+		$expected = array(
+			'Attachment.file.name', 'Attachment.file.type', 'Attachment.file.tmp_name',
+			'Attachment.file.error', 'Attachment.file.size', 'Attachment.file.full_path'
 		);
 		$this->assertEquals($expected, $this->Form->fields);
 	}


### PR DESCRIPTION
In #23, able to run test jobs using PHP8.1+MySQL, [but they were failing](https://github.com/kamilwylegala/cakephp2-php8/actions/runs/4151460875/jobs/7181780264). This pull request now passes.