### PR TITLE
Fixed: Undefined TESTS constants cause the "cake bake project" command to exit with an error

### DIFF
--- a/lib/Cake/Console/Command/Task/TestTask.php
+++ b/lib/Cake/Console/Command/Task/TestTask.php
@@ -19,6 +19,10 @@ App::uses('AppShell', 'Console/Command');
 App::uses('BakeTask', 'Console/Command/Task');
 App::uses('ClassRegistry', 'Utility');
 
+if (!defined('TESTS')) {
+	define('TESTS', APP . 'Test' . DS);
+}
+
 /**
  * Task class for creating and updating test files.
  *


### PR DESCRIPTION
Fixed: #37