### PR TITLE
feat(#46): get rid of (some) PHP deprecation warnings

### DIFF
--- a/lib/Cake/Model/Behavior/ContainableBehavior.php
+++ b/lib/Cake/Model/Behavior/ContainableBehavior.php
@@ -370,6 +370,7 @@ class ContainableBehavior extends ModelBehavior {
  */
 	public function fieldDependencies(Model $Model, $map, $fields = array()) {
 		if ($fields === false) {
+			$fields = [];
 			foreach ($map as $parent => $children) {
 				foreach ($children as $type => $bindings) {
 					foreach ($bindings as $dependency) {

--- a/lib/Cake/Model/Datasource/Database/Mysql.php
+++ b/lib/Cake/Model/Datasource/Database/Mysql.php
@@ -838,7 +838,7 @@ class Mysql extends DboSource {
  */
 	public function value($data, $column = null, $null = true) {
 		$value = parent::value($data, $column, $null);
-		if (is_numeric($value) && substr($column, 0, 3) === 'set') {
+		if (is_numeric($value) && $column !== null && str_starts_with($column, 'set')) {
 			return $this->_connection->quote($value);
 		}
 		return $value;

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -3270,13 +3270,14 @@ class DboSource extends DataSource {
 		}
 		$sign = isset($result[3]);
 
+		if ($length === null) {
+			// prevent deprecation warnings
+			return null;
+		}
+
 		$isFloat = in_array($type, array('dec', 'decimal', 'float', 'numeric', 'double'));
 		if ($isFloat && strpos($length, ',') !== false) {
 			return $length;
-		}
-
-		if ($length === null) {
-			return null;
 		}
 
 		if (isset($types[$type])) {

--- a/lib/Cake/Utility/CakeText.php
+++ b/lib/Cake/Utility/CakeText.php
@@ -193,7 +193,7 @@ class CakeText {
 		$dataReplacements = array_combine($hashKeys, array_values($data));
 		foreach ($dataReplacements as $tmpHash => $tmpValue) {
 			$tmpValue = (is_array($tmpValue)) ? '' : $tmpValue;
-			$str = str_replace($tmpHash, $tmpValue, $str);
+			$str = str_replace($tmpHash, $tmpValue ?? '', $str);
 		}
 
 		if (!isset($options['format']) && isset($options['before'])) {

--- a/lib/Cake/Utility/Inflector.php
+++ b/lib/Cake/Utility/Inflector.php
@@ -483,7 +483,7 @@ class Inflector {
  */
 	public static function underscore($camelCasedWord) {
 		if (!($result = static::_cache(__FUNCTION__, $camelCasedWord))) {
-			$underscoredWord = preg_replace('/(?<=\\w)([A-Z])/', '_\\1', $camelCasedWord);
+			$underscoredWord = preg_replace('/(?<=\\w)([A-Z])/', '_\\1', $camelCasedWord ?? '');
 			$result = mb_strtolower($underscoredWord);
 			static::_cache(__FUNCTION__, $camelCasedWord, $result);
 		}

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -573,7 +573,7 @@ class Helper extends CakeObject {
 		if ($setScope === true) {
 			$this->_modelScope = $entity;
 		}
-		$parts = array_values(Hash::filter(explode('.', $entity)));
+		$parts = $entity !== null ? array_values(Hash::filter(explode('.', $entity))) : [];
 		if (empty($parts)) {
 			return;
 		}


### PR DESCRIPTION
This PR fixes some deprecation warnings that are appearing on PHP8 if you turn the `E_USER_DEPRECATED` error_reporting level ON.

The PR probably does not get rid of ALL the deprecation warnings, but it resolves at least some of them (the ones that seemed to occur on almost every page multiple times for us).

The changes should not change any functionality, only changing the code to bude up-to-date with PHP8 "stricter standards".

The motivation is to allow users of this php8 version of Cake2 to turn change the error_reporting to a level that includes the deprecation warning and to be able to clean up the manually written code of all deprecations without the report being too cluttered with warnings from the framework itself.