### PR TITLE
Fixed deprecation warning when parsing parameters in ShellDispatcher.php

### DIFF
--- a/lib/Cake/Console/ShellDispatcher.php
+++ b/lib/Cake/Console/ShellDispatcher.php
@@ -292,7 +292,7 @@ class ShellDispatcher {
 		$params = array_merge($defaults, array_intersect_key($this->params, $defaults));
 		$isWin = false;
 		foreach ($defaults as $default => $value) {
-			if (strpos($params[$default], '\\') !== false) {
+			if (!is_null($params[$default]) && strpos($params[$default], '\\') !== false) {
 				$isWin = true;
 				break;
 			}


### PR DESCRIPTION
PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in lib/Cake/Console/ShellDispatcher.php on line 295

It broke some behat tests for my project because PHP issued warning and then session has not been able to start correctly due to "Session cannot be started after headers have already been sent" error