### PR TITLE
Fixed PHP deprecation warnings in RequestHandler and basics

### DIFF
--- a/lib/Cake/Controller/Component/RequestHandlerComponent.php
+++ b/lib/Cake/Controller/Component/RequestHandlerComponent.php
@@ -531,7 +531,7 @@ class RequestHandlerComponent extends Component {
 			return false;
 		}
 
-		list($contentType) = explode(';', env('CONTENT_TYPE'));
+		list($contentType) = explode(';', env('CONTENT_TYPE') ?? '');
 		if ($contentType === '') {
 			list($contentType) = explode(';', CakeRequest::header('CONTENT_TYPE'));
 		}

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -323,7 +323,7 @@ if (!function_exists('env')) {
 			if (isset($_SERVER['HTTPS'])) {
 				return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off');
 			}
-			return (strpos(env('SCRIPT_URI'), 'https://') === 0);
+			return (strpos(env('SCRIPT_URI') ?? '', 'https://') === 0);
 		}
 
 		if ($key === 'SCRIPT_NAME') {


### PR DESCRIPTION
PR resolves two deprecation warnings:

1. **RequestHandlerComponent might not have CONTENT_TYPE env set**

Fixed: explode(): Passing null to parameter #2 ($string) of type string is deprecated

in Cake/Controller/Component/RequestHandlerComponent.php:534

2. **basics.php might not have SCRIPT_URI env set**

## Background

Following up on my previous PR https://github.com/kamilwylegala/cakephp2-php8/pull/47

The changes should not change any functionality, only the code to be up-to-date with PHP8 "stricter standards".

The motivation is to allow users of this version of Cake2 to adjust the error_reporting to a level that includes the deprecation warnings and therefore to be able to clean up the manually written code of all deprecations without the report being too cluttered with warnings from the framework itself.
