### PR TITLE
Fix trying to read uninitialized properties when fetching call stack during exception handling

### DIFF
--- a/lib/Cake/Utility/Debugger.php
+++ b/lib/Cake/Utility/Debugger.php
@@ -593,6 +593,11 @@ class Debugger {
 					$reflectionProperties = $ref->getProperties($filter);
 					foreach ($reflectionProperties as $reflectionProperty) {
 						$reflectionProperty->setAccessible(true);
+
+						if (!$reflectionProperty->isInitialized($var)) {
+							continue;
+						}
+
 						$property = $reflectionProperty->getValue($var);
 
 						$value = static::_export($property, $depth - 1, $indent);


### PR DESCRIPTION
"Typed property ... must not be accessed before initialization" error was displayed instead of CakePHP error page with call stack