### PR TITLE
Fix passing a null input to h function

### DIFF
--- a/lib/Cake/Test/Case/BasicsTest.php
+++ b/lib/Cake/Test/Case/BasicsTest.php
@@ -243,6 +243,9 @@ class BasicsTest extends CakeTestCase {
 		$obj = new CakeResponse(array('body' => 'Body content'));
 		$result = h($obj);
 		$this->assertEquals('Body content', $result);
+
+		$result = h(null);
+		$this->assertEquals('', $result);
 	}
 
 /**

--- a/lib/Cake/basics.php
+++ b/lib/Cake/basics.php
@@ -215,6 +215,8 @@ if (!function_exists('h')) {
 			}
 		} elseif (is_bool($text)) {
 			return $text;
+		} elseif (is_null($text)) {
+			return '';
 		}
 
 		static $defaultCharset = false;


### PR DESCRIPTION
Fix the following deprecation warning: `Deprecated (8192): htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated [vendor/cakephp/cakephp/lib/Cake/basics.php, line 231]`