### PR TITLE
Fix passing null deprecation warning on CakeText::insert method

### DIFF
--- a/lib/Cake/Utility/CakeText.php
+++ b/lib/Cake/Utility/CakeText.php
@@ -164,8 +164,8 @@ class CakeText {
 			$format = sprintf(
 				'/(?<!%s)%s%%s%s/',
 				preg_quote($options['escape'], '/'),
-				str_replace('%', '%%', preg_quote($options['before'], '/')),
-				str_replace('%', '%%', preg_quote($options['after'], '/'))
+				str_replace('%', '%%', preg_quote((string)$options['before'], '/')),
+				str_replace('%', '%%', preg_quote((string)$options['after'], '/'))
 			);
 		}
 


### PR DESCRIPTION
Warning message: `Deprecated (8192): preg_quote(): Passing null to parameter #1 ($str) of type string is deprecated [vendor/cakephp/cakephp/lib/Cake/Utility/CakeText.php, line 168]`