### PR TITLE
Fix some PHP 8.1 deprecation warnings

### DIFF
--- a/lib/Cake/Model/ModelValidator.php
+++ b/lib/Cake/Model/ModelValidator.php
@@ -31,6 +31,7 @@ App::uses('Hash', 'Utility');
  * @package       Cake.Model
  * @link          https://book.cakephp.org/2.0/en/data-validation.html
  */
+#[\AllowDynamicProperties]
 class ModelValidator implements ArrayAccess, IteratorAggregate, Countable {
 
 /**

--- a/lib/Cake/Network/Http/HttpSocket.php
+++ b/lib/Cake/Network/Http/HttpSocket.php
@@ -720,7 +720,7 @@ class HttpSocket extends CakeSocket {
 			return false;
 		}
 
-		$uri['path'] = preg_replace('/^\//', null, $uri['path']);
+		$uri['path'] = preg_replace('/^\//', '', $uri['path']);
 		$uri['query'] = http_build_query($uri['query'], '', '&');
 		$uri['query'] = rtrim($uri['query'], '=');
 		$stripIfEmpty = array(
@@ -732,16 +732,16 @@ class HttpSocket extends CakeSocket {
 
 		foreach ($stripIfEmpty as $key => $strip) {
 			if (empty($uri[$key])) {
-				$uriTemplate = str_replace($strip, null, $uriTemplate);
+				$uriTemplate = str_replace($strip, '', $uriTemplate);
 			}
 		}
 
 		$defaultPorts = array('http' => 80, 'https' => 443);
 		if (array_key_exists($uri['scheme'], $defaultPorts) && $defaultPorts[$uri['scheme']] == $uri['port']) {
-			$uriTemplate = str_replace(':%port', null, $uriTemplate);
+			$uriTemplate = str_replace(':%port', '', $uriTemplate);
 		}
 		foreach ($uri as $property => $value) {
-			$uriTemplate = str_replace('%' . $property, $value, $uriTemplate);
+			$uriTemplate = str_replace('%' . $property, (string)$value, $uriTemplate);
 		}
 
 		if ($uriTemplate === '/*') {

--- a/lib/Cake/Routing/Route/CakeRoute.php
+++ b/lib/Cake/Routing/Route/CakeRoute.php
@@ -498,7 +498,7 @@ class CakeRoute {
 		}
 
 		if (is_array($params['pass'])) {
-			$params['pass'] = implode('/', array_map('rawurlencode', $params['pass']));
+			$params['pass'] = implode('/', array_map(fn($param) => rawurlencode((string)$param), $params['pass']));
 		}
 
 		$namedConfig = Router::namedConfig();


### PR DESCRIPTION
* Fix passing null to str_replace and preg_replace in HttpSocket
* Fix dynamic props usage in ModelValidator

Fixes the following deprecation warnings:
`preg_replace(): Passing null to parameter #2 ($replacement) of type array|string is deprecated [APP/Vendor/cakephp/cakephp/lib/Cake/Network/Http/HttpSocket.php, line 723]`

`str_replace(): Passing null to parameter #2 ($replace) of type array|string is deprecated [APP/Vendor/cakephp/cakephp/lib/Cake/Network/Http/HttpSocket.php, line 735]`

`str_replace(): Passing null to parameter #2 ($replace) of type array|string is deprecated [APP/Vendor/cakephp/cakephp/lib/Cake/Network/Http/HttpSocket.php, line 741]`

`str_replace(): Passing null to parameter #2 ($replace) of type array|string is deprecated [APP/Vendor/cakephp/cakephp/lib/Cake/Network/Http/HttpSocket.php, line 744]`

`Creation of dynamic property ModelValidator::$validationErrors is deprecated [APP/Vendor/cakephp/cakephp/lib/Cake/Model/ModelValidator.php, line 397]`

`rawurlencode(): Passing null to parameter #1 ($string) of type string is deprecated [APP/Vendor/cakephp/cakephp/lib/Cake/Routing/Route/CakeRoute.php, line 501]`