### PR TITLE
fix: get rid of (some) PHP deprecation warnings in CakeResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ It means that composer will look at `master` branch of repository configured und
 
 ## Changelog
 
+### 2024-01-19
+
+- `strotime()` and `preg_split()` in CakeResponse deprecation warning fixes (passing null)
+
 ### 2024-01-11
 
 - `preg_replace` deprecation warning fixes (passing null instead of `string`)

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -1164,7 +1164,7 @@ class CakeResponse {
 		$ifNoneMatchHeader = $request->header('If-None-Match');
 		$etags = array();
 		if (is_string($ifNoneMatchHeader)) {
-			$etags = preg_split('/\s*,\s*/', $ifNoneMatchHeader, null, PREG_SPLIT_NO_EMPTY);
+			$etags = preg_split('/\s*,\s*/', $ifNoneMatchHeader, 0, PREG_SPLIT_NO_EMPTY);
 		}
 		$modifiedSince = $request->header('If-Modified-Since');
 		$checks = array();
@@ -1172,7 +1172,11 @@ class CakeResponse {
 			$checks[] = in_array('*', $etags) || in_array($responseTag, $etags);
 		}
 		if ($modifiedSince) {
-			$checks[] = strtotime($this->modified()) === strtotime($modifiedSince);
+			if ($this->modified() === null) {
+				$checks[] = strtotime($modifiedSince) === false;
+			} else {
+				$checks[] = strtotime($this->modified()) === strtotime($modifiedSince);
+			}
 		}
 		if (empty($checks)) {
 			return false;


### PR DESCRIPTION
- CakeResponse.php `strotime()` and `preg_split()` warnings: in some cases `null` was being passed which is now deprecated

Another one of series of PRs to get rid of the deprecation warnings through the codebase.