### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /dist
 /tags
 *.mo
+.phpunit.result.cache
 
 # IDE and editor specific files #
 #################################

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: bash up down
+
+up:
+	docker-compose up -d
+
+down:
+	docker-compose down -v
+
+bash:
+	docker-compose exec web bash

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -1164,7 +1164,11 @@ class CakeResponse {
 		$ifNoneMatchHeader = $request->header('If-None-Match');
 		$etags = array();
 		if (is_string($ifNoneMatchHeader)) {
-			$etags = preg_split('/\s*,\s*/', $ifNoneMatchHeader, null, PREG_SPLIT_NO_EMPTY);
+			$etags = preg_split(
+				pattern: '/\s*,\s*/',
+				subject: $ifNoneMatchHeader,
+				flags: PREG_SPLIT_NO_EMPTY
+			);
 		}
 		$modifiedSince = $request->header('If-Modified-Since');
 		$checks = array();

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -1174,7 +1174,7 @@ class CakeTimeTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->i18nFormat($time, '%c');
-		$expected = 'jue 14 ene 2010 13:59:28 ' . utf8_encode(strftime('%Z', $time));
+		$expected = 'jue 14 ene 2010 13:59:28 ' . mb_convert_encoding(strftime('%Z', $time), 'UTF-8', 'ISO-8859-1');
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->i18nFormat($time, 'Time is %r, and date is %x');
@@ -1188,7 +1188,7 @@ class CakeTimeTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->i18nFormat($time, '%c');
-		$expected = 'mié 13 ene 2010 13:59:28 ' . utf8_encode(strftime('%Z', $time));
+		$expected = 'mié 13 ene 2010 13:59:28 ' . mb_convert_encoding(strftime('%Z', $time), 'UTF-8', 'ISO-8859-1');
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->i18nFormat($time, 'Time is %r, and date is %x');

--- a/lib/Cake/Test/Case/Utility/CakeTimeTest.php
+++ b/lib/Cake/Test/Case/Utility/CakeTimeTest.php
@@ -279,7 +279,7 @@ class CakeTimeTest extends CakeTestCase {
 		$this->assertEquals('on 2007-09-25', $result);
 
 		$result = $this->Time->timeAgoInWords('2007-9-25', '%x');
-		$this->assertEquals('on ' . strftime('%x', strtotime('2007-9-25')), $result);
+		$this->assertEquals('on ' . @strftime('%x', strtotime('2007-9-25')), $result);
 
 		$result = $this->Time->timeAgoInWords(
 			strtotime('+2 weeks +2 days'),
@@ -303,7 +303,7 @@ class CakeTimeTest extends CakeTestCase {
 			strtotime('+2 months +2 days'),
 			array('end' => '1 month', 'format' => '%x')
 		);
-		$this->assertEquals('on ' . strftime('%x', strtotime('+2 months +2 days')), $result);
+		$this->assertEquals('on ' . @strftime('%x', strtotime('+2 months +2 days')), $result);
 	}
 
 /**
@@ -1174,7 +1174,7 @@ class CakeTimeTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->i18nFormat($time, '%c');
-		$expected = 'jue 14 ene 2010 13:59:28 ' . mb_convert_encoding(strftime('%Z', $time), 'UTF-8', 'ISO-8859-1');
+		$expected = 'jue 14 ene 2010 13:59:28 ' . mb_convert_encoding(@strftime('%Z', $time), 'UTF-8', 'ISO-8859-1');
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->i18nFormat($time, 'Time is %r, and date is %x');
@@ -1188,7 +1188,7 @@ class CakeTimeTest extends CakeTestCase {
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->i18nFormat($time, '%c');
-		$expected = 'mié 13 ene 2010 13:59:28 ' . mb_convert_encoding(strftime('%Z', $time), 'UTF-8', 'ISO-8859-1');
+		$expected = 'mié 13 ene 2010 13:59:28 ' . mb_convert_encoding(@strftime('%Z', $time), 'UTF-8', 'ISO-8859-1');
 		$this->assertEquals($expected, $result);
 
 		$result = $this->Time->i18nFormat($time, 'Time is %r, and date is %x');

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -1176,7 +1176,7 @@ class CakeTime {
 				$valid = Multibyte::checkMultibyte($format);
 			}
 			if (!$valid) {
-				$format = utf8_encode($format);
+				$format = mb_convert_encoding($format, 'UTF-8', 'ISO-8859-1');
 			}
 		}
 		return $format;

--- a/lib/Cake/Utility/CakeTime.php
+++ b/lib/Cake/Utility/CakeTime.php
@@ -1167,7 +1167,7 @@ class CakeTime {
  * @return string formatted string with correct encoding.
  */
 	protected static function _strftime($format, $timestamp) {
-		$format = strftime($format, $timestamp);
+		$format = @strftime($format, $timestamp);
 		$encoding = Configure::read('App.encoding');
 		if (!empty($encoding) && $encoding === 'UTF-8') {
 			if (function_exists('mb_check_encoding')) {

--- a/lib/Cake/View/Helper.php
+++ b/lib/Cake/View/Helper.php
@@ -632,7 +632,7 @@ class Helper extends CakeObject {
  * @return array An array containing the identity elements of an entity
  */
 	public function entity() {
-		return explode('.', $this->_entityPath);
+		return explode('.', (string)$this->_entityPath);
 	}
 
 /**

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2767,7 +2767,7 @@ class FormHelper extends AppHelper {
 		}
 
 		if (is_numeric($value)) {
-			$value = strftime('%Y-%m-%d %H:%M:%S', $value);
+			$value = @strftime('%Y-%m-%d %H:%M:%S', $value);
 		}
 		$meridian = 'am';
 		$pos = strpos($value, '-');
@@ -3021,7 +3021,7 @@ class FormHelper extends AppHelper {
 					$data = $options['monthNames'];
 				} else {
 					for ($m = 1; $m <= 12; $m++) {
-						$data[sprintf("%02s", $m)] = strftime("%m", mktime(1, 1, 1, $m, 1, 1999));
+						$data[sprintf("%02s", $m)] = @strftime("%m", mktime(1, 1, 1, $m, 1, 1999));
 					}
 				}
 				break;

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2708,7 +2708,7 @@ class FormHelper extends AppHelper {
 		}
 
 		$selects = array();
-		foreach (preg_split('//', $dateFormat, -1, PREG_SPLIT_NO_EMPTY) as $char) {
+		foreach (preg_split('//', (string)$dateFormat, -1, PREG_SPLIT_NO_EMPTY) as $char) {
 			switch ($char) {
 				case 'Y':
 					$attrs['Year']['value'] = $year;

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2767,7 +2767,19 @@ class FormHelper extends AppHelper {
 		}
 
 		if (is_numeric($value)) {
-			$value = strftime('%Y-%m-%d %H:%M:%S', $value);
+			try {
+				$value = datefmt_format(
+					datefmt_create(
+						locale: setLocale(LC_TIME, 0),
+						dateType: \IntlDateFormatter::FULL,
+						timeType: \IntlDateFormatter::FULL,
+						pattern: 'yyyy-MM-dd HH:mm:SS'
+					),
+					$value
+				);
+			} catch (\Error) {
+				$value = date('Y-m-d H:i:s', $value);
+			}
 		}
 		$meridian = 'am';
 		$pos = strpos($value, '-');
@@ -3021,7 +3033,19 @@ class FormHelper extends AppHelper {
 					$data = $options['monthNames'];
 				} else {
 					for ($m = 1; $m <= 12; $m++) {
-						$data[sprintf("%02s", $m)] = strftime("%m", mktime(1, 1, 1, $m, 1, 1999));
+						try {
+							$data[sprintf("%02s", $m)] = datefmt_format(
+								datefmt_create(
+									locale: setLocale(LC_TIME, 0),
+									dateType: \IntlDateFormatter::FULL,
+									timeType: \IntlDateFormatter::FULL,
+									pattern: 'MM'
+								),
+								mktime(1, 1, 1, $m, 1, 1999)
+							);
+						} catch (\Error) {
+							$data[sprintf("%02s", $m)] = date('m', mktime(1, 1, 1, $m, 1, 1999));
+						}
 					}
 				}
 				break;

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2767,19 +2767,7 @@ class FormHelper extends AppHelper {
 		}
 
 		if (is_numeric($value)) {
-			try {
-				$value = datefmt_format(
-					datefmt_create(
-						locale: setLocale(LC_TIME, 0),
-						dateType: \IntlDateFormatter::FULL,
-						timeType: \IntlDateFormatter::FULL,
-						pattern: 'yyyy-MM-dd HH:mm:SS'
-					),
-					$value
-				);
-			} catch (\Error) {
-				$value = date('Y-m-d H:i:s', $value);
-			}
+			$value = strftime('%Y-%m-%d %H:%M:%S', $value);
 		}
 		$meridian = 'am';
 		$pos = strpos($value, '-');
@@ -3033,19 +3021,7 @@ class FormHelper extends AppHelper {
 					$data = $options['monthNames'];
 				} else {
 					for ($m = 1; $m <= 12; $m++) {
-						try {
-							$data[sprintf("%02s", $m)] = datefmt_format(
-								datefmt_create(
-									locale: setLocale(LC_TIME, 0),
-									dateType: \IntlDateFormatter::FULL,
-									timeType: \IntlDateFormatter::FULL,
-									pattern: 'MM'
-								),
-								mktime(1, 1, 1, $m, 1, 1999)
-							);
-						} catch (\Error) {
-							$data[sprintf("%02s", $m)] = date('m', mktime(1, 1, 1, $m, 1, 1999));
-						}
+						$data[sprintf("%02s", $m)] = strftime("%m", mktime(1, 1, 1, $m, 1, 1999));
 					}
 				}
 				break;


### PR DESCRIPTION
- Switch deprecated utf8_encode function to mb_convert_encoding function.
- Fix PHP 8.1 deprecation warnings on Helper and FormHelper.
- Hide strftime deprecation warning.
- Fix preg_split deprecated null param limit on CakeResponse::checkNotModified