### PR TITLE
fix: get rid of PHP deprecation warnings in CakeResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ It means that composer will look at `master` branch of repository configured und
 
 ## Changelog
 
+### 2024-02-02
+
+- `str_len` deprecation warning fix in CakeResponse (passing null instead of `string`)
+
 ### 2024-01-11
 
 - `preg_replace` deprecation warning fixes (passing null instead of `string`)

--- a/lib/Cake/Network/CakeResponse.php
+++ b/lib/Cake/Network/CakeResponse.php
@@ -516,7 +516,7 @@ class CakeResponse {
 			if (ini_get('mbstring.func_overload') & 2 && function_exists('mb_strlen')) {
 				$this->length($offset + mb_strlen($this->_body, '8bit'));
 			} else {
-				$this->length($this->_headers['Content-Length'] = $offset + strlen($this->_body));
+				$this->length($this->_headers['Content-Length'] = $offset + ($this->_body === null ? 0 : strlen($this->_body)));
 			}
 		}
 	}


### PR DESCRIPTION
- CakeResponse.php strlen() no longer accepts null as a parameter -> added check to see if it's not null