### PR TITLE
Fix for console, and FormHelper

### DIFF
--- a/lib/Cake/Console/Shell.php
+++ b/lib/Cake/Console/Shell.php
@@ -355,7 +355,8 @@ class Shell extends CakeObject {
  */
 	public function hasMethod(string $name) {
 		try {
-			$method = new ReflectionMethod($this, $name);
+			$thisName = is_object($this) ? get_class($this) : $this;
+			$method = new ReflectionMethod($thisName, $name);
 			if (!$method->isPublic() || substr($name, 0, 1) === '_') {
 				return false;
 			}

--- a/lib/Cake/View/Helper/FormHelper.php
+++ b/lib/Cake/View/Helper/FormHelper.php
@@ -2561,7 +2561,7 @@ class FormHelper extends AppHelper {
 						$attributes['value'] = date('a');
 					}
 				} else {
-					$date = date_create($attributes['value']);
+					$date = date_create($value);
 					$attributes['value'] = null;
 					if ($date) {
 						$attributes['value'] = $date->format('a');


### PR DESCRIPTION

- Shell console classes were sometimes unable to detect the appropriate class name. This fixes that.
- AM/PM values for time-based inputs had a logic error in the original CakePHP method; this fixes that.