### PR TITLE
Fix deprecation error in I18n

### DIFF
--- a/lib/Cake/I18n/I18n.php
+++ b/lib/Cake/I18n/I18n.php
@@ -437,7 +437,13 @@ class I18n {
 				}
 
 				if ($translations !== false) {
-					$this->_domains[$domain][$this->_lang][$this->category] = $translations;
+					if ($this->_domains[$domain][$this->_lang] === false) {
+						$this->_domains[$domain][$this->_lang] = [
+							$this->category => $translations
+						];
+					} else {
+						$this->_domains[$domain][$this->_lang][$this->category] = $translations;
+					}
 					$this->_noLocale = false;
 					break 2;
 				}
@@ -445,7 +451,13 @@ class I18n {
 		}
 
 		if (empty($this->_domains[$domain][$this->_lang][$this->category])) {
-			$this->_domains[$domain][$this->_lang][$this->category] = array();
+			if ($this->_domains[$domain][$this->_lang] === false) {
+				$this->_domains[$domain][$this->_lang] = [
+					$this->category => []
+				];
+			} else {
+				$this->_domains[$domain][$this->_lang][$this->category] = [];
+			}
 			return $domain;
 		}
 


### PR DESCRIPTION
Utility\I18n's protected _bindTextDomain() method was sometimes assigning an array key to an array element that evaluated as false. This was trigging deprecation error 'Automatic conversion of false to array is deprecated'.

This modification checks whether the array element is false and explicitly converts it to an array if it is.

closes #70