### PR TITLE
Remove constructs that deprecate with PHP 8.4

### DIFF
--- a/lib/Cake/Console/Command/Task/FixtureTask.php
+++ b/lib/Cake/Console/Command/Task/FixtureTask.php
@@ -248,7 +248,7 @@ class FixtureTask extends BakeTask {
 		$this->_Schema = new CakeSchema();
 		$data = $this->_Schema->read(array('models' => false, 'connection' => $this->connection));
 		if (!isset($data['tables'][$useTable])) {
-			$this->err("<warning>Warning:</warning> Could not find the '${useTable}' table for ${model}.");
+			$this->err("<warning>Warning:</warning> Could not find the '{$useTable}' table for {$model}.");
 			return null;
 		}
 

--- a/lib/Cake/Console/Command/Task/ModelTask.php
+++ b/lib/Cake/Console/Command/Task/ModelTask.php
@@ -170,7 +170,7 @@ class ModelTask extends BakeTask {
 		while (!$valid) {
 			$len = strlen(count($options) + 1);
 			foreach ($options as $i => $option) {
-				$this->out(sprintf("%${len}d. %s", $i + 1, $option));
+				$this->out(sprintf("%{$len}d. %s", $i + 1, $option));
 			}
 			if (empty($prompt)) {
 				$prompt = __d('cake_console', 'Make a selection from the choices above');
@@ -901,7 +901,7 @@ class ModelTask extends BakeTask {
 			$this->out(__d('cake_console', 'Possible Models based on your current database:'));
 			$len = strlen($count + 1);
 			for ($i = 0; $i < $count; $i++) {
-				$this->out(sprintf("%${len}d. %s", $i + 1, $this->_modelNames[$i]));
+				$this->out(sprintf("%{$len}d. %s", $i + 1, $this->_modelNames[$i]));
 			}
 		}
 		return $this->_tables;

--- a/lib/Cake/Controller/Component/Auth/BaseAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/BaseAuthorize.php
@@ -89,7 +89,7 @@ abstract class BaseAuthorize {
  * @return mixed
  * @throws CakeException
  */
-	public function controller(Controller $controller = null) {
+	public function controller(?Controller $controller = null) {
 		if ($controller) {
 			if (!$controller instanceof Controller) {
 				throw new CakeException(__d('cake_dev', '$controller needs to be an instance of Controller'));

--- a/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php
+++ b/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php
@@ -43,7 +43,7 @@ class ControllerAuthorize extends BaseAuthorize {
  * @return mixed
  * @throws CakeException
  */
-	public function controller(Controller $controller = null) {
+	public function controller(?Controller $controller = null) {
 		if ($controller) {
 			if (!method_exists($controller, 'isAuthorized')) {
 				throw new CakeException(__d('cake_dev', '$controller does not implement an %s method.', 'isAuthorized()'));

--- a/lib/Cake/Controller/Component/AuthComponent.php
+++ b/lib/Cake/Controller/Component/AuthComponent.php
@@ -453,7 +453,7 @@ class AuthComponent extends Component {
  * @param CakeRequest|null $request The request to authenticate for. If empty, the current request will be used.
  * @return bool True if $user is authorized, otherwise false
  */
-	public function isAuthorized($user = null, CakeRequest $request = null) {
+	public function isAuthorized($user = null, ?CakeRequest $request = null) {
 		if (empty($user) && !$this->user()) {
 			return false;
 		}

--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -344,7 +344,7 @@ class SecurityComponent extends Component {
  * @link https://book.cakephp.org/2.0/en/core-libraries/components/security-component.html#handling-blackhole-callbacks
  * @throws BadRequestException
  */
-	public function blackHole(Controller $controller, $error = '', SecurityException $exception = null) {
+	public function blackHole(?Controller $controller, $error = '', ?SecurityException $exception = null) {
 		if (!$this->blackHoleCallback) {
 			$this->_throwException($exception);
 		}

--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -344,7 +344,7 @@ class SecurityComponent extends Component {
  * @link https://book.cakephp.org/2.0/en/core-libraries/components/security-component.html#handling-blackhole-callbacks
  * @throws BadRequestException
  */
-	public function blackHole(?Controller $controller, $error = '', ?SecurityException $exception = null) {
+	public function blackHole(Controller $controller, $error = '', ?SecurityException $exception = null) {
 		if (!$this->blackHoleCallback) {
 			$this->_throwException($exception);
 		}
@@ -822,7 +822,7 @@ class SecurityComponent extends Component {
  * @param string $method Method to execute
  * @param array $params Parameters to send to method
  * @return mixed Controller callback method's response
- * @throws BadRequestException When a the blackholeCallback is not callable.
+ * @throws BadRequestException When the blackholeCallback is not callable.
  */
 	protected function _callback(Controller $controller, $method, $params = array()) {
 		if (!is_callable(array($controller, $method))) {

--- a/lib/Cake/Error/exceptions.php
+++ b/lib/Cake/Error/exceptions.php
@@ -297,7 +297,7 @@ class PrivateActionException extends CakeException {
 	protected $_messageTemplate = 'Private Action %s::%s() is not directly accessible.';
 
 //@codingStandardsIgnoreStart
-	public function __construct($message, $code = 404, Exception $previous = null) {
+	public function __construct($message, $code = 404, ?Exception $previous = null) {
 		parent::__construct($message, $code, $previous);
 	}
 //@codingStandardsIgnoreEnd

--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -527,7 +527,7 @@ class DboSource extends DataSource {
  * @param PDOStatement $query the query to extract the error from if any
  * @return string Error message with error number
  */
-	public function lastError(PDOStatement $query = null) {
+	public function lastError(?PDOStatement $query = null) {
 		if ($query) {
 			$error = $query->errorInfo();
 		} else {
@@ -2761,7 +2761,7 @@ class DboSource extends DataSource {
  * @param Model $Model A reference to the Model instance making the query
  * @return string SQL fragment
  */
-	public function conditions($conditions, $quoteValues = true, $where = true, Model $Model = null) {
+	public function conditions($conditions, $quoteValues = true, $where = true, ?Model $Model = null) {
 		$clause = $out = '';
 
 		if ($where) {
@@ -2804,7 +2804,7 @@ class DboSource extends DataSource {
  * @param Model $Model A reference to the Model instance making the query
  * @return string SQL fragment
  */
-	public function conditionKeysToString($conditions, $quoteValues = true, Model $Model = null) {
+	public function conditionKeysToString($conditions, $quoteValues = true, ?Model $Model = null) {
 		$out = array();
 		$data = $columnType = null;
 
@@ -2909,7 +2909,7 @@ class DboSource extends DataSource {
  * @param Model $Model Model object initiating the query
  * @return string
  */
-	protected function _parseKey($key, $value, Model $Model = null) {
+	protected function _parseKey($key, $value, ?Model $Model = null) {
 		$operatorMatch = '/^(((' . implode(')|(', $this->_sqlOps);
 		$operatorMatch .= ')\\x20?)|<[>=]?(?![^>]+>)\\x20?|[>=!]{1,3}(?!<)\\x20?)/is';
 		$bound = (strpos($key, '?') !== false || (is_array($value) && strpos($key, ':') !== false));
@@ -3083,7 +3083,7 @@ class DboSource extends DataSource {
  * @param Model $Model Model reference (used to look for virtual field)
  * @return string ORDER BY clause
  */
-	public function order($keys, $direction = 'ASC', Model $Model = null) {
+	public function order($keys, $direction = 'ASC', ?Model $Model = null) {
 		if (!is_array($keys)) {
 			$keys = array($keys);
 		}
@@ -3166,7 +3166,7 @@ class DboSource extends DataSource {
  * @param Model $Model The model to get group by fields for.
  * @return string Group By clause or null.
  */
-	public function group($fields, Model $Model = null) {
+	public function group($fields, ?Model $Model = null) {
 		if (empty($fields)) {
 			return null;
 		}
@@ -3196,7 +3196,7 @@ class DboSource extends DataSource {
  * @param Model $Model A reference to the Model instance making the query
  * @return string|null HAVING clause or null
  */
-	public function having($fields, $quoteValues = true, Model $Model = null) {
+	public function having($fields, $quoteValues = true, ?Model $Model = null) {
 		if (!$fields) {
 			return null;
 		}

--- a/lib/Cake/Model/Model.php
+++ b/lib/Cake/Model/Model.php
@@ -3913,7 +3913,7 @@ class Model extends CakeObject implements CakeEventListener {
  *  If null a new ModelValidator instance will be made using current model object
  * @return ModelValidator
  */
-	public function validator(ModelValidator $instance = null) {
+	public function validator(?ModelValidator $instance = null) {
 		if ($instance) {
 			$this->_validator = $instance;
 		} elseif (!$this->_validator) {

--- a/lib/Cake/Test/Case/Console/ShellTest.php
+++ b/lib/Cake/Test/Case/Console/ShellTest.php
@@ -607,7 +607,7 @@ class ShellTest extends CakeTestCase {
 
 		$this->Shell->interactive = false;
 
-		$contents = "<?php{$eol}echo 'test';${eol}\$te = 'st';{$eol}";
+		$contents = "<?php{$eol}echo 'test';{$eol}\$te = 'st';{$eol}";
 		$result = $this->Shell->createFile($file, $contents);
 		$this->assertTrue($result);
 		$this->assertTrue(file_exists($file));

--- a/lib/Cake/View/JsonView.php
+++ b/lib/Cake/View/JsonView.php
@@ -65,7 +65,7 @@ class JsonView extends View {
  *
  * @param Controller $controller Controller instance.
  */
-	public function __construct(Controller $controller = null) {
+	public function __construct(?Controller $controller = null) {
 		parent::__construct($controller);
 		if (isset($controller->response) && $controller->response instanceof CakeResponse) {
 			$controller->response->type('json');

--- a/lib/Cake/View/View.php
+++ b/lib/Cake/View/View.php
@@ -330,7 +330,7 @@ class View extends CakeObject {
  *
  * @param Controller $controller A controller object to pull View::_passedVars from.
  */
-	public function __construct(Controller $controller = null) {
+	public function __construct(?Controller $controller = null) {
 		if (is_object($controller)) {
 			$count = count($this->_passedVars);
 			for ($j = 0; $j < $count; $j++) {

--- a/lib/Cake/View/XmlView.php
+++ b/lib/Cake/View/XmlView.php
@@ -65,7 +65,7 @@ class XmlView extends View {
  *
  * @param Controller $controller Controller instance.
  */
-	public function __construct(Controller $controller = null) {
+	public function __construct(?Controller $controller = null) {
 		parent::__construct($controller);
 
 		if (isset($controller->response) && $controller->response instanceof CakeResponse) {


### PR DESCRIPTION
PHP 8.4 deprecates type declarations of the form `function x(string $y = null)` - see [longer explanation here](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated). PHP 9 will no longer support such implicit nullable parameters.
This PR fixes this pattern everywhere.

How to reproduce: run a syntax check with PHP 8.4:
`find . -type f \( -name "*.php" -o -name "*.ctp" \) -exec php -d error_reporting=32765 -l {} \; | grep -v 'No syntax errors detected'`
Result before this PR:
```
PHP 8.4.0alpha2 (cli) (built: Jul 19 2024 19:23:28) (NTS)
Deprecated: ControllerAuthorize::controller(): Implicitly marking parameter $controller as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Controller/Component/Auth/ControllerAuthorize.php on line 46
Deprecated: BaseAuthorize::controller(): Implicitly marking parameter $controller as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Controller/Component/Auth/BaseAuthorize.php on line 92
Deprecated: SecurityComponent::blackHole(): Implicitly marking parameter $exception as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Controller/Component/SecurityComponent.php on line 347
Deprecated: AuthComponent::isAuthorized(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Controller/Component/AuthComponent.php on line 456
Deprecated: PrivateActionException::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Error/exceptions.php on line 300
Deprecated: DboSource::lastError(): Implicitly marking parameter $query as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Model/Datasource/DboSource.php on line 530
Deprecated: DboSource::conditions(): Implicitly marking parameter $Model as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Model/Datasource/DboSource.php on line 2764
Deprecated: DboSource::conditionKeysToString(): Implicitly marking parameter $Model as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Model/Datasource/DboSource.php on line 2807
Deprecated: DboSource::_parseKey(): Implicitly marking parameter $Model as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Model/Datasource/DboSource.php on line 2912
Deprecated: DboSource::order(): Implicitly marking parameter $Model as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Model/Datasource/DboSource.php on line 3086
Deprecated: DboSource::group(): Implicitly marking parameter $Model as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Model/Datasource/DboSource.php on line 3169
Deprecated: DboSource::having(): Implicitly marking parameter $Model as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Model/Datasource/DboSource.php on line 3199
Deprecated: Model::validator(): Implicitly marking parameter $instance as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/Model/Model.php on line 3916
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /app/lib/Cake/Console/Command/Task/FixtureTask.php on line 251
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /app/lib/Cake/Console/Command/Task/FixtureTask.php on line 251
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /app/lib/Cake/Console/Command/Task/ModelTask.php on line 173
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /app/lib/Cake/Console/Command/Task/ModelTask.php on line 904
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /app/lib/Cake/Test/Case/Console/ShellTest.php on line 610
Deprecated: XmlView::__construct(): Implicitly marking parameter $controller as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/View/XmlView.php on line 68
Deprecated: JsonView::__construct(): Implicitly marking parameter $controller as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/View/JsonView.php on line 68
Deprecated: View::__construct(): Implicitly marking parameter $controller as nullable is deprecated, the explicit nullable type must be used instead in /app/lib/Cake/View/View.php on line 333
```

With this PR, the upcoming syntax errors are fixed.