### PR TITLE
Fix potential CSRF circumvention with custom HTTP methods

### DIFF
--- a/lib/Cake/Controller/Component/SecurityComponent.php
+++ b/lib/Cake/Controller/Component/SecurityComponent.php
@@ -227,7 +227,7 @@ class SecurityComponent extends Component {
 	public function startup(Controller $controller) {
 		$this->request = $controller->request;
 		$this->_action = $controller->request->params['action'];
-		$hasData = ($controller->request->data || $controller->request->is(array('put', 'post', 'delete', 'patch')));
+		$hasData = ($controller->request->data || !$controller->request->is(['head', 'get', 'options']));
 		try {
 			$this->_methodsRequired($controller);
 			$this->_secureRequired($controller);

--- a/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
+++ b/lib/Cake/Test/Case/Controller/Component/SecurityComponentTest.php
@@ -162,6 +162,7 @@ class SecurityComponentTest extends CakeTestCase {
  */
 	public function setUp() : void {
 		parent::setUp();
+		$_SERVER['REQUEST_METHOD'] = 'GET';
 
 		$request = $this->getMock('CakeRequest', array('here'), array('posts/index', false));
 		$request->addParams(array('controller' => 'posts', 'action' => 'index'));
@@ -321,7 +322,7 @@ class SecurityComponentTest extends CakeTestCase {
  * @return void
  */
 	public function testRequireSecureSucceed() {
-		$_SERVER['REQUEST_METHOD'] = 'Secure';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$this->Controller->request['action'] = 'posted';
 		$_SERVER['HTTPS'] = 'on';
 		$this->Controller->Security->requireSecure('posted');


### PR DESCRIPTION
Attackers might be able to circumvent CakePHPs CSRF/request body protection, if the controller method *does not* check that the request is actually POST but uses the request body data. This issue was already patched in CakePHP 3, this PR backports the fix to CakePHP 2. 

The upstream PR contains other, not so relevant changes to the CSRF token and the upstream commit refactors some unit tests. These changes are not necessary to fix this issue and are not ported.

Upstream patch: https://github.com/cakephp/cakephp/commit/0f818a23a876c01429196bf7623e1e94a50230f0
Upstream PR: https://github.com/cakephp/cakephp/pull/7742